### PR TITLE
Fix max string size calculation.

### DIFF
--- a/src/mcd-connection.c
+++ b/src/mcd-connection.c
@@ -1335,7 +1335,7 @@ translate_g_error (GQuark domain,
 
               if (p != NULL)
                 {
-                  gchar *tmp = g_strndup (message, message - p);
+                  gchar *tmp = g_strndup (message, p - message);
 
                   /* The syntactic restrictions for error names are the same
                    * as for interface names. */


### PR DESCRIPTION
This was crashing mission-control when any of the active connection managers disappears from dbus.
That subtraction was causing an underflow. In the end a g_malloc() was getting called with a huge number.