### PR TITLE
account: Fix property name

### DIFF
--- a/src/mcd-account.c
+++ b/src/mcd-account.c
@@ -3442,7 +3442,7 @@ mcd_account_class_init (McdAccountClass * klass)
 
     g_object_class_install_property
         (object_class, PROP_CONNECTIVITY_MONITOR,
-         g_param_spec_object ("connectivity monitor",
+         g_param_spec_object ("connectivity-monitor",
                               "Connectivity monitor",
                               "Connectivity monitor",
                               MCD_TYPE_CONNECTIVITY_MONITOR,


### PR DESCRIPTION
Spaces are not valid characters in property names, and never were.
Until recently GLib silently fixed up the name by replacing the
space with '-', but now tightened up the validation.